### PR TITLE
Add 127.0.0.1 to listen directive

### DIFF
--- a/stubs/site.conf
+++ b/stubs/site.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name {DOMAIN};
     root {ROOT};
     index index.php;


### PR DESCRIPTION
Hi. Thanks for writing this package.

For some reason I kept getting `404 - Not Found` for my sites after I had run the `phpbrew:link` command.
I compared the generated .conf file with valet.conf, and noticed that valet's default configuration uses `listen 127.0.0.1:80;` in stead of just `listen 80;`
After making this small change in the generated .conf file and restarting nginx, everything works as expected.
I have no idea why adding the IP address is necessary on my system, but it obviously makes some kind of difference.